### PR TITLE
Add code to deal with race in install plans

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -15,51 +15,7 @@ func TestE2e(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	By("Deploying the Compliance Operator")
-	ocApplyFromString(`---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-compliance
-`)
-
-	ocApplyFromString(`---
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: compliance-operator
-  namespace: openshift-marketplace
-spec:
-  displayName: Compliance Operator Upstream
-  publisher: github.com/openshift/compliance-operator
-  sourceType: grpc
-  image: quay.io/compliance-operator/compliance-operator-index:latest
-
-`)
-
-	ocApplyFromString(`---
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: compliance-operator-sub
-  namespace: openshift-compliance
-spec:
-  channel: alpha
-  name: compliance-operator
-  source: compliance-operator
-  sourceNamespace: openshift-marketplace
-`)
-
-	ocApplyFromString(`---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: compliance-operator
-  namespace: openshift-compliance
-spec:
-  targetNamespaces:
-  - openshift-compliance
-`)
+	ensureOperator()
 
 	By("Switching context to compliance-operator NS")
 	oc("project", "openshift-compliance")
@@ -68,10 +24,29 @@ spec:
 		time.Sleep(30 * time.Second)
 	}
 
-	By("Waiting for all install plans")
+	By("Getting install plans")
 	ipraw := oc("get", "installplans", "-o", `jsonpath={range .items[:]}{.metadata.name}{"\n"}{end}`)
 	ips := strings.Split(ipraw, "\n")
 
+	// NOTE(jaosorior): If there is more than one install plan
+	// one of them will fail... this might be a bug in the OLM
+	// Let's delete them and wait for the reconcile to create
+	// one again.
+	if len(ips) > 1 {
+		By("Race in install plans... re-installing")
+		oc("delete", "installplans", "--all")
+		oc("delete", "csv", "--all")
+		oc("delete", "subscriptions.operators", "--all")
+		time.Sleep(30 * time.Second)
+
+		ensureOperator()
+		time.Sleep(30 * time.Minute)
+
+		ipraw = oc("get", "installplans", "-o", `jsonpath={range .items[:]}{.metadata.name}{"\n"}{end}`)
+		ips = strings.Split(ipraw, "\n")
+	}
+
+	By("Waiting for install plan")
 	for _, ip := range ips {
 		ocWaitFor("condition=installed", "installplan", ip)
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -18,6 +18,54 @@ const defaultOCLongWaitTimeout = "--timeout=10m"
 const scanDoneTimeout = 5 * time.Minute
 const defaultSleep = 5 * time.Second
 
+func ensureOperator() {
+	By("Deploying the Compliance Operator")
+	ocApplyFromString(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-compliance
+`)
+
+	ocApplyFromString(`---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: compliance-operator
+  namespace: openshift-marketplace
+spec:
+  displayName: Compliance Operator Upstream
+  publisher: github.com/openshift/compliance-operator
+  sourceType: grpc
+  image: quay.io/compliance-operator/compliance-operator-index:latest
+
+`)
+
+	ocApplyFromString(`---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  name: compliance-operator
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+`)
+
+	ocApplyFromString(`---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance
+`)
+}
+
 func do(cmd string, args ...string) string {
 	execcmd := exec.Command(cmd, args...)
 	output, err := execcmd.CombinedOutput()


### PR DESCRIPTION
In some cases, the install plans might have a race and two will be
created... one of the install plans will fail as the other one
succeeded. In order to deal with this, we re-install.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>