### PR TITLE
Add e2e tests for view-result sub-command

### DIFF
--- a/internal/viewresult/result.go
+++ b/internal/viewresult/result.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
 	goerrors "github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -175,7 +176,7 @@ func (h *ResultHelper) displayAvailableFixes(rule *unstructured.Unstructured) er
 		return fmt.Errorf("Unable to get %s of %s/%s of type %s: %s", "avaliableFixes", rule.GetNamespace(), rule.GetName(), rule.GetKind(), err)
 	}
 	if found && fixes != nil {
-		h.table.Append([]string{"Avalailable Fix", "Yes"})
+		h.table.Append([]string{"Available Fix", "Yes"})
 		for _, fixObjRaw := range fixes {
 			fixObj, ok := fixObjRaw.(map[string]interface{})
 			if !ok {
@@ -196,7 +197,7 @@ func (h *ResultHelper) displayAvailableFixes(rule *unstructured.Unstructured) er
 			h.table.Append([]string{"Fix Object", buf.String()})
 		}
 	} else {
-		h.table.Append([]string{"Avalailable Fix", "No"})
+		h.table.Append([]string{"Available Fix", "No"})
 	}
 
 	return nil

--- a/tests/e2e/viewresult_test.go
+++ b/tests/e2e/viewresult_test.go
@@ -1,0 +1,32 @@
+package e2e
+
+import (
+	"math/rand"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("viewresult", func() {
+	var targetResult string
+	BeforeEach(func() {
+		// Ensure there's some results in there
+		withCISScan("viewresult-scan")
+		results := oc("get", "compliancecheckresults",
+			"-o", `jsonpath={range .items[:]}{.metadata.name}{"\n"}{end}`)
+		resSlice := strings.Split(results, "\n")
+		idx := rand.Intn(len(resSlice))
+		targetResult = resSlice[idx]
+	}, float64(scanDoneTimeout))
+
+	It("gets relevant info for result", func() {
+		out := oc("compliance", "view-result", targetResult)
+		Expect(out).To(MatchRegexp(`Status.*`))
+		Expect(out).To(MatchRegexp(`Severity.*`))
+		Expect(out).To(MatchRegexp(`Description.*`))
+		Expect(out).To(MatchRegexp(`Controls.*`))
+		Expect(out).To(MatchRegexp(`Available Fix.*`))
+		Expect(out).To(MatchRegexp(`Remediation Created.*`))
+	})
+})


### PR DESCRIPTION
This also fixes a typo in the command's output.

Closes https://github.com/openshift/oc-compliance/issues/15

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>