### PR TITLE
Add e2e tests for fetch-fixes sub-command and fix command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ oc compliance view-result rhcos4-e8-worker-sysctl-kernel-kptr-restrict
 +----------------------+---------------------------------------------------------------------------------+
 ```
 
+### fetch-fixes
+
+Helps download the remediations the Compliance Operator recommends. These as
+stored as YAML files in the filesystem, so one would be able to apply them to a
+cluster.
+
+Note that MachineConfigs are not complete and require extra parsing:
+
+* Setting an appropriate name
+* Setting metadata for the pool they'll apply to
+
+```
+oc compliance fetch-fixes profile ocp4-cis -o tmp/
+No fixes to persist for rule 'ocp4-accounts-restrict-service-account-tokens'
+...
+No fixes to persist for rule 'ocp4-api-server-audit-log-maxbackup'
+Persisted rule fix to tmp/ocp4-api-server-audit-log-maxsize.yaml
+Persisted rule fix to tmp/ocp4-api-server-encryption-provider-cipher.yaml
+Persisted rule fix to tmp/ocp4-api-server-encryption-provider-config.yaml
+```
+
 Installing
 ----------
 

--- a/cmd/fetchfixes.go
+++ b/cmd/fetchfixes.go
@@ -18,14 +18,14 @@ func init() {
 func NewCmdFetchFixes(streams genericclioptions.IOStreams) *cobra.Command {
 	var (
 		usageExamples = `
-  # Fetch from compliancescan
-  %[1]s %[2]s compliancescan [resource name] -o [directory]
+  # Fetch from a rule
+  %[1]s %[2]s rule [resource name] -o [directory]
   
-  # Fetch from compliancesuite
-  %[1]s %[2]s compliancesuite [resource name] -o [directory]
+  # Fetch from a profile
+  %[1]s %[2]s profile [resource name] -o [directory]
   
-  # Fetch from scansettingbindings
-  %[1]s %[2]s scansettingbindings [resource name] -o [directory]
+  # Fetch from a complianceRemediation
+  %[1]s %[2]s complianceremediation [resource name] -o [directory]
 `
 	)
 

--- a/tests/e2e/fetchfixes_test.go
+++ b/tests/e2e/fetchfixes_test.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func assertFetchFixesFetchedSomething(dir string) {
+	By("Finding remediations")
+	dirraw := do("find", dir, "-name", "*.yaml")
+	dirs := strings.Split(dirraw, "\n")
+
+	By("Assert we got results")
+	Expect(len(dirs)).Should(BeNumerically(">", 0))
+}
+
+var _ = Describe("fetch-fixes", func() {
+	var dir string
+	BeforeEach(func() {
+		var tmpErr error
+		dir, tmpErr = ioutil.TempDir("", "fetch-fixes")
+		Expect(tmpErr).ShouldNot(HaveOccurred())
+		By(fmt.Sprintf("Created temporary directory for this test: %s", dir))
+	})
+	Context("With a remediation", func() {
+		var targetRem string
+
+		BeforeEach(func() {
+			withCISScan("fetch-fixes-scan")
+			rems := oc("get", "complianceremediations",
+				"-o", `jsonpath={range .items[:]}{.metadata.name}{"\n"}{end}`)
+			remsSlice := strings.Split(rems, "\n")
+			idx := rand.Intn(len(remsSlice))
+			targetRem = remsSlice[idx]
+		}, float64(scanDoneTimeout))
+
+		It("fetches fixes for ComplianceRemediation", func() {
+			oc("compliance", "fetch-fixes", "complianceremediation", targetRem, "-o", dir)
+		})
+	})
+
+	Context("With parsed content", func() {
+		It("fetches fixes for profile", func() {
+			oc("compliance", "fetch-fixes", "profile", "ocp4-cis", "-o", dir)
+		})
+	})
+})


### PR DESCRIPTION
This adds e2e tests for the aforementioned subcommand, it also fixes the
command's help docs to reflect the actual objects it works with.

This also adds relevant docs to the README.

Closes https://github.com/openshift/oc-compliance/issues/12
Closes https://github.com/openshift/oc-compliance/issues/3

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>