### PR TITLE
Add hyphen to usage so the correct string shows up

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "oc compliance",
+	Use:   "oc-compliance",
 	Short: "A set of utilities that come along with the compliance-operator.",
 	Long:  `A set of utilities that come along with the compliance-operator.`,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Cobra doesn't take spaces into account, so we use the hyphen instead to
show `oc-compliance` instead of just `oc`. This is still appropriate, as
the binary is `oc-compliance` anyway, even if it's picked up by the `oc`
plugin system.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>