### PR TITLE
Enable using a custom image for fetch-raw sub-command

### DIFF
--- a/cmd/fetchraw.go
+++ b/cmd/fetchraw.go
@@ -56,6 +56,8 @@ ComplianceScan, ComplianceSuite, or ScanSettingBinding to a specified directory.
 	}
 
 	cmd.Flags().StringVarP(&o.OutputPath, "output", "o", ".", "The path where you want to persist the raw results to")
+	cmd.Flags().StringVarP(&o.Image, "image", "i", "registry.access.redhat.com/ubi8/ubi:latest",
+		"The container image to use to fetch the raw results from the compliance scan. Must contain the cp and tar commands.")
 	cmd.Flags().BoolVar(&o.HTML, "html", false, "Whether to render the raw results to HTML (Requires the 'oscap' command)")
 	o.ConfigFlags.AddFlags(cmd.Flags())
 

--- a/internal/fetchraw/compliancescans.go
+++ b/internal/fetchraw/compliancescans.go
@@ -301,6 +301,13 @@ func getPVCExtractorPod(objName, ns, image, claimName string) *corev1.Pod {
 					},
 				},
 			},
+			Tolerations: []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+				},
+			},
 			Volumes: []corev1.Volume{
 				{
 					Name: "raw-results-vol",

--- a/internal/fetchraw/compliancescans.go
+++ b/internal/fetchraw/compliancescans.go
@@ -35,16 +35,18 @@ type ComplianceScanHelper struct {
 	kind       string
 	name       string
 	outputPath string
+	image      string
 	html       bool
 	genericclioptions.IOStreams
 }
 
-func NewComplianceScanHelper(kuser common.KubeClientUser, name, outputPath string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewComplianceScanHelper(kuser common.KubeClientUser, name, outputPath, image string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
 	return &ComplianceScanHelper{
 		kuser:      kuser,
 		name:       name,
 		kind:       "ComplianceScan",
 		outputPath: outputPath,
+		image:      image,
 		html:       html,
 		gvk: schema.GroupVersionResource{
 			Group:    common.CmpAPIGroup,
@@ -98,7 +100,7 @@ func (h *ComplianceScanHelper) Handle() error {
 	}
 
 	// Create extractor pod
-	extractorPod := getPVCExtractorPod(res.GetName(), rsnamespace, claimName)
+	extractorPod := getPVCExtractorPod(res.GetName(), rsnamespace, h.image, claimName)
 	extractorPod, err = h.kuser.Clientset().CoreV1().Pods(rsnamespace).Create(context.TODO(), extractorPod, metav1.CreateOptions{})
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return err
@@ -273,7 +275,7 @@ func getPVCExtractorPodLabels(objName string) map[string]string {
 	}
 }
 
-func getPVCExtractorPod(objName, ns, claimName string) *corev1.Pod {
+func getPVCExtractorPod(objName, ns, image, claimName string) *corev1.Pod {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -288,7 +290,7 @@ func getPVCExtractorPod(objName, ns, claimName string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "pv-extract-pod",
-					Image:   "registry.access.redhat.com/ubi8/ubi:latest",
+					Image:   image,
 					Command: []string{"sleep", "inf"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/internal/fetchraw/compliancesuites.go
+++ b/internal/fetchraw/compliancesuites.go
@@ -20,17 +20,19 @@ type ComplianceSuiteHelper struct {
 	name       string
 	kind       string
 	outputPath string
+	image      string
 	html       bool
 	genericclioptions.IOStreams
 }
 
-func NewComplianceSuiteHelper(kuser common.KubeClientUser, name, outputPath string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewComplianceSuiteHelper(kuser common.KubeClientUser, name, outputPath, image string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
 	return &ComplianceSuiteHelper{
 		kuser:      kuser,
 		name:       name,
 		kind:       "ComplianceSuite",
 		outputPath: outputPath,
 		html:       html,
+		image:      image,
 		gvk: schema.GroupVersionResource{
 			Group:    common.CmpAPIGroup,
 			Version:  common.CmpResourceVersion,
@@ -60,7 +62,7 @@ func (h *ComplianceSuiteHelper) Handle() error {
 		if err := os.Mkdir(scanDir, 0700); err != nil {
 			return fmt.Errorf("Unable to create directory %s: %s", scanDir, err)
 		}
-		helper := NewComplianceScanHelper(h.kuser, scanName, scanDir, h.html, h.IOStreams)
+		helper := NewComplianceScanHelper(h.kuser, scanName, scanDir, h.image, h.html, h.IOStreams)
 		if err = helper.Handle(); err != nil {
 			return fmt.Errorf("Unable to process results from suite %s: %s", h.name, err)
 		}

--- a/internal/fetchraw/options.go
+++ b/internal/fetchraw/options.go
@@ -15,6 +15,7 @@ type FetchRawOptions struct {
 	common.CommandContext
 
 	OutputPath string
+	Image      string
 	HTML       bool
 }
 
@@ -38,6 +39,10 @@ func (o *FetchRawOptions) Validate() error {
 		return fmt.Errorf("The output path must be a directory")
 	}
 
+	if o.Image == "" {
+		return fmt.Errorf("The image parameter can't be empty")
+	}
+
 	objref, err := common.ValidateObjectArgs(o.Args)
 	if err != nil {
 		return err
@@ -52,11 +57,11 @@ func (o *FetchRawOptions) Validate() error {
 
 	switch objref.Type {
 	case common.ScanSettingBinding:
-		o.Helper = NewScanSettingBindingHelper(o.Kuser, objref.Name, o.OutputPath, o.HTML, o.IOStreams)
+		o.Helper = NewScanSettingBindingHelper(o.Kuser, objref.Name, o.OutputPath, o.Image, o.HTML, o.IOStreams)
 	case common.ComplianceSuite:
-		o.Helper = NewComplianceSuiteHelper(o.Kuser, objref.Name, o.OutputPath, o.HTML, o.IOStreams)
+		o.Helper = NewComplianceSuiteHelper(o.Kuser, objref.Name, o.OutputPath, o.Image, o.HTML, o.IOStreams)
 	case common.ComplianceScan:
-		o.Helper = NewComplianceScanHelper(o.Kuser, objref.Name, o.OutputPath, o.HTML, o.IOStreams)
+		o.Helper = NewComplianceScanHelper(o.Kuser, objref.Name, o.OutputPath, o.Image, o.HTML, o.IOStreams)
 	default:
 		return fmt.Errorf("Invalid object type for this command")
 	}

--- a/internal/fetchraw/scansettingbindings.go
+++ b/internal/fetchraw/scansettingbindings.go
@@ -17,17 +17,19 @@ type ScanSettingBindingHelper struct {
 	name       string
 	kind       string
 	outputPath string
+	image      string
 	html       bool
 	genericclioptions.IOStreams
 }
 
-func NewScanSettingBindingHelper(kuser common.KubeClientUser, name, outputPath string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewScanSettingBindingHelper(kuser common.KubeClientUser, name, outputPath, image string, html bool, streams genericclioptions.IOStreams) common.ObjectHelper {
 	return &ScanSettingBindingHelper{
 		kuser:      kuser,
 		name:       name,
 		kind:       "ScanSettingBinding",
 		outputPath: outputPath,
 		html:       html,
+		image:      image,
 		gvk: schema.GroupVersionResource{
 			Group:    common.CmpAPIGroup,
 			Version:  common.CmpResourceVersion,
@@ -45,6 +47,6 @@ func (h *ScanSettingBindingHelper) Handle() error {
 	}
 	suiteName := res.GetName()
 
-	helper := NewComplianceSuiteHelper(h.kuser, suiteName, h.outputPath, h.html, h.IOStreams)
+	helper := NewComplianceSuiteHelper(h.kuser, suiteName, h.outputPath, h.image, h.html, h.IOStreams)
 	return helper.Handle()
 }


### PR DESCRIPTION
This adds the `-i` flag, which allows users to specify a custom image
when fetching the raw results.

This is useful in disconnected environments where users don't have
access to a standard registry

Additionally, it adds tolerations for the pod to be able to schedule on master
nodes.