### PR TITLE
Add capability for `fetch-fixes` to write complete MachineConfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,9 @@ Helps download the remediations the Compliance Operator recommends. These are
 stored as YAML files in the filesystem, so one would then be able to apply them to a
 cluster.
 
-Note that MachineConfigs are not complete and require extra parsing:
-
-* Setting an appropriate name
-* Setting metadata for the pool they'll apply to
+Note that if the MachineConfigs objects will be rendered with the default roles
+`master` and `worker`. If you need different ones, you can add them via the
+`--mc-roles` flag.
 
 ```
 oc compliance fetch-fixes profile ocp4-cis -o tmp/

--- a/cmd/fetchfixes.go
+++ b/cmd/fetchfixes.go
@@ -56,6 +56,8 @@ ComplianceRemediation into a specified directory.`,
 	}
 
 	cmd.Flags().StringVarP(&o.OutputPath, "output", "o", ".", "The path where you want to persist the fix objects to")
+	cmd.Flags().StringSliceVarP(&o.MCRoles, "mc-roles", "", []string{"worker", "master"},
+		"If the remediation(s) are MachineConfig objects, render them with the following roles")
 	o.ConfigFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/internal/common/yaml.go
+++ b/internal/common/yaml.go
@@ -12,8 +12,8 @@ import (
 )
 
 // PersistObjectToYamlFile persists the given object to a yaml file in the given path
-func PersistObjectToYamlFile(name string, obj *unstructured.Unstructured, outputDir string, serializer *k8sserial.Serializer) (string, error) {
-	path := path.Join(outputDir, name+".yaml")
+func PersistObjectToYamlFile(fileNameBase string, obj *unstructured.Unstructured, outputDir string, serializer *k8sserial.Serializer) (string, error) {
+	path := path.Join(outputDir, fileNameBase+".yaml")
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return "", err
@@ -21,7 +21,7 @@ func PersistObjectToYamlFile(name string, obj *unstructured.Unstructured, output
 
 	defer f.Close()
 
-	if err := PersistObjectToYaml(name, obj, f, serializer); err != nil {
+	if err := PersistObjectToYaml(fileNameBase, obj, f, serializer); err != nil {
 		return "", nil
 	}
 

--- a/internal/fetchfixes/common.go
+++ b/internal/fetchfixes/common.go
@@ -1,0 +1,61 @@
+package fetchfixes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sserial "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/oc-compliance/internal/common"
+)
+
+const roleKey = "machineconfiguration.openshift.io/role"
+
+type FixPersister struct {
+	outputPath string
+	mcRoles    []string
+	genericclioptions.IOStreams
+}
+
+func (fp *FixPersister) handleObjectPersistence(ys *k8sserial.Serializer, fileNameBase string, fix *unstructured.Unstructured) error {
+	if fix.GetKind() == "MachineConfig" {
+		for _, role := range fp.mcRoles {
+			handleMCMetadata(fix, fileNameBase, role)
+			fileWithRole := fmt.Sprintf("%s-%s", role, fileNameBase)
+			err := fp.persistFix(ys, fileWithRole, fix)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	err := fp.persistFix(ys, fileNameBase, fix)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (fp *FixPersister) persistFix(ys *k8sserial.Serializer, fileNameBase string, fix *unstructured.Unstructured) error {
+	path, err := common.PersistObjectToYamlFile(fileNameBase, fix, fp.outputPath, ys)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(fp.Out, "Persisted rule fix to %s\n", path)
+	return nil
+}
+
+func handleMCMetadata(obj *unstructured.Unstructured, baseName, role string) {
+	// priority, name and role
+	obj.SetName(fmt.Sprintf("75-%s-%s", role, baseName))
+	if len(obj.GetLabels()) == 0 {
+		obj.SetLabels(make(map[string]string))
+	}
+
+	labels := obj.GetLabels()
+	labels[roleKey] = role
+	obj.SetLabels(labels)
+}

--- a/internal/fetchfixes/context.go
+++ b/internal/fetchfixes/context.go
@@ -12,6 +12,8 @@ type FetchFixesContext struct {
 	common.CommandContext
 
 	OutputPath string
+	// MachineConfig roles
+	MCRoles []string
 }
 
 func NewFetchFixesContext(streams genericclioptions.IOStreams) *FetchFixesContext {
@@ -41,11 +43,11 @@ func (o *FetchFixesContext) Validate() error {
 
 	switch objref.Type {
 	case common.Rule:
-		o.Helper = NewRuleHelper(o.Kuser, objref.Name, o.OutputPath, o.IOStreams)
+		o.Helper = NewRuleHelper(o.Kuser, objref.Name, o.OutputPath, o.MCRoles, o.IOStreams)
 	case common.Profile:
-		o.Helper = NewProfileHelper(o.Kuser, objref.Name, o.OutputPath, o.IOStreams)
+		o.Helper = NewProfileHelper(o.Kuser, objref.Name, o.OutputPath, o.MCRoles, o.IOStreams)
 	case common.ComplianceRemediation:
-		o.Helper = NewComplianceRemediationHelper(o.Kuser, objref.Name, o.OutputPath, o.IOStreams)
+		o.Helper = NewComplianceRemediationHelper(o.Kuser, objref.Name, o.OutputPath, o.MCRoles, o.IOStreams)
 	default:
 		return fmt.Errorf("Invalid object type for this command")
 	}

--- a/internal/fetchfixes/profiles.go
+++ b/internal/fetchfixes/profiles.go
@@ -16,10 +16,11 @@ type ProfileHelper struct {
 	kind       string
 	name       string
 	outputPath string
+	mcRoles    []string
 	genericclioptions.IOStreams
 }
 
-func NewProfileHelper(kuser common.KubeClientUser, name string, outputPath string, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewProfileHelper(kuser common.KubeClientUser, name string, outputPath string, mcRoles []string, streams genericclioptions.IOStreams) common.ObjectHelper {
 	return &ProfileHelper{
 		kuser: kuser,
 		name:  name,
@@ -30,6 +31,7 @@ func NewProfileHelper(kuser common.KubeClientUser, name string, outputPath strin
 			Resource: "profiles",
 		},
 		outputPath: outputPath,
+		mcRoles:    mcRoles,
 		IOStreams:  streams,
 	}
 }
@@ -42,7 +44,7 @@ func (h *ProfileHelper) Handle() error {
 
 	rules, err := common.GetRulesFromProfile(p)
 	for _, r := range rules {
-		rh := NewRuleHelper(h.kuser, r, h.outputPath, h.IOStreams)
+		rh := NewRuleHelper(h.kuser, r, h.outputPath, h.mcRoles, h.IOStreams)
 		rh.Handle()
 	}
 	return nil

--- a/tests/e2e/fetchfixes_test.go
+++ b/tests/e2e/fetchfixes_test.go
@@ -41,6 +41,18 @@ var _ = Describe("fetch-fixes", func() {
 
 		It("fetches fixes for ComplianceRemediation", func() {
 			oc("compliance", "fetch-fixes", "complianceremediation", targetRem, "-o", dir)
+			assertFetchFixesFetchedSomething(dir)
+		})
+	})
+
+	Context("With an MC remediation", func() {
+		It("fetches fixes for rule", func() {
+			oc("compliance", "fetch-fixes", "rule", "rhcos4-coreos-pti-kernel-argument", "-o", dir)
+			assertFetchFixesFetchedSomething(dir)
+			name := do("grep", "-R", "name:.*75.*worker", dir)
+			Expect(name).ToNot(BeEmpty())
+			label := do("grep", "-R", "machineconfiguration.openshift.io/role: master", dir)
+			Expect(label).ToNot(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Before, we would write the raw MachineConfigs on disk, which don't
contain names nor metadata as those are filled by the Compliace
Operator.

With these change these could be used directly instead of asking
users to edit them. This is done by adding the needed labels and name to
the objects, based on the contents of a new flag introduced called
`--mc-roles`.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>