### PR TITLE
fetch-fixes: Add support for adding extra manifests (ArgoCD)

### DIFF
--- a/cmd/fetchfixes.go
+++ b/cmd/fetchfixes.go
@@ -58,6 +58,11 @@ ComplianceRemediation into a specified directory.`,
 	cmd.Flags().StringVarP(&o.OutputPath, "output", "o", ".", "The path where you want to persist the fix objects to")
 	cmd.Flags().StringSliceVarP(&o.MCRoles, "mc-roles", "", []string{"worker", "master"},
 		"If the remediation(s) are MachineConfig objects, render them with the following roles")
+	cmd.Flags().StringVarP(&o.ExtraManifestBuildType, "manifest-prepare", "", "default",
+		"Prepare the manifests for another system to use them. e.g. a GitOps engine.\n"+
+			"Available Options:\n"+
+			"\t* 'default'\t- does nothing.\n"+
+			"\t* 'ArgoCD'\t- prepares the manifest for ArgoCD (OpenShift GitOps)\n")
 	o.ConfigFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/internal/fetchfixes/emb/argocd_manifest_builder.go
+++ b/internal/fetchfixes/emb/argocd_manifest_builder.go
@@ -1,0 +1,223 @@
+package emb
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const ArgoCDBuilderName = "ArgoCD"
+
+const saAndPerms = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  name: mcp-job-sa
+  namespace: openshift-gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-job-sa-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+rules:
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-job-sa-rolebinding
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcp-job-sa-role
+subjects:
+  - kind: ServiceAccount
+    name: mcp-job-sa
+    namespace: openshift-gitops
+`
+
+const mcpPreHook = `---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  name: mcp-pause-job
+  namespace: openshift-gitops
+spec:
+  template:
+    spec:
+      containers:
+        - image: registry.redhat.io/openshift4/ose-cli:v4.4
+          command:
+            - /bin/bash
+            - -c
+            - |
+              export HOME=/tmp/mcp
+              echo ""
+              echo -n "Pausing MachineConfigPools."
+              MCPS=({{ range .MCRoles }}"{{.}}" {{end}})
+              for MCP in "${MCPS[@]}"
+              do
+                oc patch machineconfigpools $MCP -p '{"spec":{"paused":true}}' --type=merge
+              done
+          imagePullPolicy: Always
+          name: mcp-pause-job
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: mcp-job-sa
+      serviceAccountName: mcp-job-sa
+      terminationGracePeriodSeconds: 30
+`
+
+const mcpPostHook = `---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  name: mcp-unpause-job
+  namespace: openshift-gitops
+spec:
+  template:
+    spec:
+      containers:
+        - image: registry.redhat.io/openshift4/ose-cli:v4.4
+          command:
+            - /bin/bash
+            - -c
+            - |
+              export HOME=/tmp/mcp
+              echo ""
+              echo -n "Un-pausing MachineConfigPools."
+              MCPS=({{ range .MCRoles }}"{{.}}" {{end}})
+              for MCP in "${MCPS[@]}"
+              do
+                oc patch machineconfigpools $MCP -p '{"spec":{"paused":false}}' --type=merge
+              done
+              echo "DONE"
+              echo -n "Waiting for the MachineConfigPools to converge."
+              sleep $SLEEP
+              MCPS=({{ range .MCRoles }}"{{.}}" {{end}})
+              for MCP in ${MCPS[@]}
+              do
+                until oc wait --for condition=updated --timeout=60s mcp $MCP
+                do
+                  echo -n "...still waiting for $MCP to converge"
+                  sleep $SLEEP
+                done
+              done
+              echo "DONE"
+          imagePullPolicy: Always
+          name: mcp-unpause-job
+          env:
+          - name: SLEEP
+            value: "5"
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: mcp-job-sa
+      serviceAccountName: mcp-job-sa
+      terminationGracePeriodSeconds: 30
+`
+
+type ArgoCDManifestBuilder struct {
+	needsMCManifests bool
+}
+
+func NewArgoCDManifestBuilder() ExtraManifestBuilder {
+	return &ArgoCDManifestBuilder{}
+}
+
+func getMCTemplates() map[string]*template.Template {
+	return map[string]*template.Template{
+		"sa-and-perms.yaml":  template.Must(template.New("sa-and-perms").Parse(saAndPerms)),
+		"mcp-pre-hook.yaml":  template.Must(template.New("pre-hook").Parse(mcpPreHook)),
+		"mcp-post-hook.yaml": template.Must(template.New("post-hook").Parse(mcpPostHook)),
+	}
+}
+
+func (amb *ArgoCDManifestBuilder) BuildObjectContext(fix, objOwner *unstructured.Unstructured) error {
+	if fix.GetKind() == "MachineConfig" {
+		amb.needsMCManifests = true
+	}
+
+	// TODO figure out dependency depth
+	if fixHasDependencies(fix, objOwner) {
+		amb.addWaveAnnotations(fix)
+	}
+	return nil
+}
+
+func (amb *ArgoCDManifestBuilder) addWaveAnnotations(obj *unstructured.Unstructured) {
+	if len(obj.GetAnnotations()) == 0 {
+		obj.SetAnnotations(make(map[string]string))
+	}
+	anns := obj.GetAnnotations()
+	// TODO: Replace with actual ArgoCD import?
+	// TODO: Keep track of dependencies and add higher waves if necessary
+	anns["argocd.argoproj.io/sync-wave"] = "2"
+	obj.SetAnnotations(anns)
+}
+
+func (amb *ArgoCDManifestBuilder) FlushManifests(path string, roles []string) error {
+	if amb.needsMCManifests {
+		for fpath, t := range getMCTemplates() {
+			var buf bytes.Buffer
+			vars := struct {
+				MCRoles []string
+			}{
+				MCRoles: roles,
+			}
+			if err := t.Execute(&buf, vars); err != nil {
+				return err
+			}
+			if err := amb.writeManifest(filepath.Join(path, fpath), buf.String()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (amb *ArgoCDManifestBuilder) writeManifest(path, content string) error {
+	return ioutil.WriteFile(path, []byte(content), 0600)
+}
+
+func fixHasDependencies(fix, objOwner *unstructured.Unstructured) bool {
+	return objHasDependencies(fix) || objHasDependencies(objOwner)
+}
+
+func objHasDependencies(obj *unstructured.Unstructured) bool {
+	if len(obj.GetAnnotations()) > 0 {
+		for key := range obj.GetAnnotations() {
+			// TODO: Figure out dependency depth and if dependency is reconcilable
+			if strings.HasSuffix(key, "depends-on") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/fetchfixes/emb/extramanifestbuilder.go
+++ b/internal/fetchfixes/emb/extramanifestbuilder.go
@@ -1,0 +1,8 @@
+package emb
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+type ExtraManifestBuilder interface {
+	BuildObjectContext(fix, ctx *unstructured.Unstructured) error
+	FlushManifests(path string, roles []string) error
+}

--- a/internal/fetchfixes/emb/noop_manifest_builder.go
+++ b/internal/fetchfixes/emb/noop_manifest_builder.go
@@ -1,0 +1,22 @@
+package emb
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const NoopBuilderName = "default"
+
+type NoopManifestBuilder struct {
+}
+
+func NewNoopManifestBuilder() ExtraManifestBuilder {
+	return &NoopManifestBuilder{}
+}
+
+func (nmb *NoopManifestBuilder) BuildObjectContext(fix, objOwner *unstructured.Unstructured) error {
+	return nil
+}
+
+func (nmb *NoopManifestBuilder) FlushManifests(path string, roles []string) error {
+	return nil
+}

--- a/internal/fetchfixes/profiles.go
+++ b/internal/fetchfixes/profiles.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/openshift/oc-compliance/internal/common"
+	"github.com/openshift/oc-compliance/internal/fetchfixes/emb"
 )
 
 type ProfileHelper struct {
@@ -17,10 +18,14 @@ type ProfileHelper struct {
 	name       string
 	outputPath string
 	mcRoles    []string
+	emb        emb.ExtraManifestBuilder
 	genericclioptions.IOStreams
 }
 
-func NewProfileHelper(kuser common.KubeClientUser, name string, outputPath string, mcRoles []string, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewProfileHelper(
+	kuser common.KubeClientUser, name string, outputPath string, mcRoles []string,
+	emb emb.ExtraManifestBuilder, streams genericclioptions.IOStreams,
+) common.ObjectHelper {
 	return &ProfileHelper{
 		kuser: kuser,
 		name:  name,
@@ -32,6 +37,7 @@ func NewProfileHelper(kuser common.KubeClientUser, name string, outputPath strin
 		},
 		outputPath: outputPath,
 		mcRoles:    mcRoles,
+		emb:        emb,
 		IOStreams:  streams,
 	}
 }
@@ -44,7 +50,7 @@ func (h *ProfileHelper) Handle() error {
 
 	rules, err := common.GetRulesFromProfile(p)
 	for _, r := range rules {
-		rh := NewRuleHelper(h.kuser, r, h.outputPath, h.mcRoles, h.IOStreams)
+		rh := NewRuleHelper(h.kuser, r, h.outputPath, h.mcRoles, h.emb, h.IOStreams)
 		rh.Handle()
 	}
 	return nil

--- a/internal/fetchfixes/rules.go
+++ b/internal/fetchfixes/rules.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/openshift/oc-compliance/internal/common"
+	"github.com/openshift/oc-compliance/internal/fetchfixes/emb"
 )
 
 type RuleHelper struct {
@@ -19,9 +20,12 @@ type RuleHelper struct {
 	gvk   schema.GroupVersionResource
 	kind  string
 	name  string
+	emb   emb.ExtraManifestBuilder
 }
 
-func NewRuleHelper(kuser common.KubeClientUser, name string, outputPath string, mcRoles []string, streams genericclioptions.IOStreams) common.ObjectHelper {
+func NewRuleHelper(
+	kuser common.KubeClientUser, name string, outputPath string, mcRoles []string,
+	emb emb.ExtraManifestBuilder, streams genericclioptions.IOStreams) common.ObjectHelper {
 	return &RuleHelper{
 		FixPersister: FixPersister{
 			outputPath: outputPath,
@@ -30,6 +34,7 @@ func NewRuleHelper(kuser common.KubeClientUser, name string, outputPath string, 
 		},
 		kuser: kuser,
 		name:  name,
+		emb:   emb,
 		kind:  "Rule",
 		gvk: schema.GroupVersionResource{
 			Group:    common.CmpAPIGroup,
@@ -62,6 +67,7 @@ func (h *RuleHelper) Handle() error {
 		if needsSuffix {
 			fileName = fmt.Sprintf("%s-%d", r.GetName(), idx)
 		}
+		h.emb.BuildObjectContext(fix, r)
 		err := h.handleObjectPersistence(yamlSerializer, fileName, fix)
 		if err != nil {
 			return err

--- a/internal/viewresult/result.go
+++ b/internal/viewresult/result.go
@@ -15,8 +15,8 @@ import (
 	k8sserial "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/openshift/oc-compliance/internal/common"
 	"github.com/olekukonko/tablewriter"
+	"github.com/openshift/oc-compliance/internal/common"
 )
 
 const (


### PR DESCRIPTION
This adds the concept of extra manifest builders for the `fetch-fixes`
subcommand. The main use-case is that some GitOps systems will require
extra manifests to function appropriately.

e.g.

MachineConfigs don't play well with ArgoCD, so we need an extra job in
the form of hooks to pause/unpause the MachineConfigPool.

this takes the form of the `--manifest-prepare` flag, which may be
`default` (doing nothing) or `ArgoCD` (adding the manifests necessary
for ArgoCD).

## TODO

* This PR does very basic dependency resolution... but only goes 1 level deep. We need to make this more dynamic in the future.
* Only XCCDF ID dependency resolution is done, we need to do Kubernetes object resolution too.
* Enforcement remediations are completely skipped.
* ArgoCD doesn't support patching kube objects... so not all remediations will work.