### PR TITLE
Render rules for controls as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,35 @@ $ oc compliance rerun-now scansettingbinding nist-moderate
 ### controls
 
 Creates a report of what compliance standards and controls will a benchmark
-fulfil.
+fulfil. It also shows the rules that address each control.
 
 ```
 $ oc compliance controls profile rhcos4-moderate
++-------------+------------------+-----------------------------------------------------------------------------------+
+|  FRAMEWORK  |     CONTROLS     |                                       RULES                                       |
++-------------+------------------+-----------------------------------------------------------------------------------+
+| NERC-CIP    | CIP-002-3 R1.1   | rhcos4-sysctl-kernel-kptr-restrict                                                |
++             +------------------+                                                                                   +
+|             | CIP-002-3 R1.2   |                                                                                   |
++             +------------------+-----------------------------------------------------------------------------------+
+|             | CIP-003-3 R1.3   | rhcos4-no-netrc-files                                                             |
++             +------------------+                                                                                   +
+|             | CIP-003-3 R3     |                                                                                   |
++             +------------------+                                                                                   +
+|             | CIP-003-3 R3.1   |                                                                                   |
++             +------------------+                                                                                   +
+|             | CIP-003-3 R3.2   |                                                                                   |
++             +------------------+                                                                                   +
+|             | CIP-003-3 R3.3   |                                                                                   |
++             +------------------+-----------------------------------------------------------------------------------+
+|             | CIP-003-3 R4.2   | rhcos4-configure-crypto-policy                                                    |
++             +                  +-----------------------------------------------------------------------------------+
+...
 ```
+
+This will display the rules and controls for all benchmarks.
+
+It's also possible to filter for a specific benchmark using the `-b` flag.
 
 ### bind
 

--- a/cmd/controls.go
+++ b/cmd/controls.go
@@ -45,5 +45,7 @@ func NewCmdControls(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	ctx.ConfigFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&ctx.Benchmark, "benchmark", "b", controls.AllBenchmarks,
+		"The benchmark we want to retrieve the controls for")
 	return cmd
 }

--- a/internal/controls/context.go
+++ b/internal/controls/context.go
@@ -7,8 +7,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const AllBenchmarks = "all"
+
 type ControlsContext struct {
 	common.CommandContext
+	Benchmark string
 }
 
 func NewControlsContext(streams genericclioptions.IOStreams) *ControlsContext {
@@ -29,7 +32,7 @@ func (o *ControlsContext) Validate() error {
 
 	switch objref.Type {
 	case common.Profile:
-		o.Helper = NewProfileHelper(o.Kuser, objref.Name, o.IOStreams)
+		o.Helper = NewProfileHelper(o.Kuser, objref.Name, o.IOStreams, o.Benchmark)
 	default:
 		return fmt.Errorf("Invalid object type for this command")
 	}


### PR DESCRIPTION
In our controls subcommand, we used to only render the benchmark and the
control. However, it's often the case that folks need to know what rule
addresses what control. So this introduces that.

So, the output would look as follows:

```
$ oc compliance controls profile ocp4-e8
+-------------+------------------+-----------------------------------------------+
|  FRAMEWORK  |     CONTROLS     |                     RULES                     |
+-------------+------------------+-----------------------------------------------+
| CIS-OCP     | 1.2.34           | ocp4-api-server-encryption-provider-cipher    |
+             +------------------+-----------------------------------------------+
|             | 1.2.35           | ocp4-api-server-tls-cipher-suites             |
+             +------------------+-----------------------------------------------+
|             | 5.1.1            | ocp4-rbac-limit-cluster-admin                 |
+             +------------------+-----------------------------------------------+
...
```

We're also now able to filter by benchmark using the `-b` flag.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>