### PR TITLE
OCPBUGS-3862: bind: fix typo in command help

### DIFF
--- a/cmd/bind.go
+++ b/cmd/bind.go
@@ -25,7 +25,7 @@ func NewCmdBind(streams genericclioptions.IOStreams) *cobra.Command {
   %[1]s %[2]s --dry-run -N <binding name> [-S <scansetting name>] <objtype/objname> [..<objtype/objname>]
 
   # Example: Creating a ScanSettingBinding named "mybinding" that applies the "default" ScanSettings to the standard CIS Profiles.
-  %[1]s %[2]s -N mybinding profile/ocp4-cis profie/ocp4-cis-node
+  %[1]s %[2]s -N mybinding profile/ocp4-cis profile/ocp4-cis-node
 
   # Example: Creating a ScanSettingBinding named "mybinding" that applies the "default-auto-apply" ScanSettings to a tailored CIS Profile.
   %[1]s %[2]s -N mybinding -S default-auto-apply tailoredprofile/ocp4-cis-node-tailored


### PR DESCRIPTION
Both `ocp4-cis` and `ocp4-cis-node` are profiles based on https://docs.openshift.com/container-platform/4.9/security/compliance_operator/oc-compliance-plug-in-using.html#using-scan-setting-bindings_oc-compliance-plug-in-understanding.