### PR TITLE
e2e: Bump rerun timeout

### DIFF
--- a/tests/e2e/rerunnow_test.go
+++ b/tests/e2e/rerunnow_test.go
@@ -27,7 +27,7 @@ var _ = Describe("rerun-now", func() {
 			By("checking the scan is re-kicked")
 			Eventually(func() string {
 				return oc("get", "compliancesuite", "rerun-now-scan", "-o", `jsonpath={.status.phase}`)
-			}, reRunTimeout).Should(ContainSubstring(`PENDING`))
+			}, reRunTimeout).Should(BeElementOf([]string{"PENDING", "LAUNCHING", "RUNNING"}))
 
 			By("waiting for scan to be done")
 			ocWaitLongFor("condition=ready", "compliancesuite", "rerun-now-scan")

--- a/tests/e2e/rerunnow_test.go
+++ b/tests/e2e/rerunnow_test.go
@@ -3,6 +3,11 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
+)
+
+const (
+	reRunTimeout = 10 * time.Second
 )
 
 var _ = Describe("rerun-now", func() {
@@ -22,7 +27,7 @@ var _ = Describe("rerun-now", func() {
 			By("checking the scan is re-kicked")
 			Eventually(func() string {
 				return oc("get", "compliancesuite", "rerun-now-scan", "-o", `jsonpath={.status.phase}`)
-			}).Should(ContainSubstring(`PENDING`))
+			}, reRunTimeout).Should(ContainSubstring(`PENDING`))
 
 			By("waiting for scan to be done")
 			ocWaitLongFor("condition=ready", "compliancesuite", "rerun-now-scan")


### PR DESCRIPTION
Eventually waits for just one second by default, this might not be
enough. Let's bump the timeout to 10s.
