### PR TITLE
Update go version for build CI

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.19
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.19
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
We recently updated go deps to use 1.19 so we can update kubernetes dependencies. This commit updates the version of golang we use in CI to match so we don't attempt to run CI incompatible changes between the source and what we're building with.

  https://github.com/openshift/oc-compliance/pull/220