### PR TITLE
Update golang version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oc-compliance
 
-go 1.19
+go 1.20
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5


### PR DESCRIPTION
Some of the newer dependencies we're using need go 1.20. Let's update so
we can start landing those patches.
