### PR TITLE
Ensure raw-result-extractor pod is short lived

### DIFF
--- a/internal/fetchraw/compliancescans.go
+++ b/internal/fetchraw/compliancescans.go
@@ -306,11 +306,12 @@ func getPVCExtractorPod(objName, ns, image, claimName string) *corev1.Pod {
 			Labels:       getPVCExtractorPodLabels(objName),
 		},
 		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
 					Name:    "pv-extract-pod",
 					Image:   image,
-					Command: []string{"sleep", "inf"},
+					Command: []string{"sleep", "300"},
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},


### PR DESCRIPTION
This ensures the pod mouting the PVC eventually completes and frees the volume, avoiding blocking any future compliance scans.

Follow up from https://github.com/ComplianceAsCode/compliance-operator/pull/556