### PR TITLE
docs: add installation instructions for oc-compliance plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ oc compliance -h
 ### macOS / Apple Silicon
 
 The container image is currently published for `linux/amd64` only.  
-On Apple Silicon, build it :
+Build it and add it to 
 
 ```bash
+brew install go
 make build
-```
+cp ./bin/oc-compliance /opt/homebrew/bin
+chmod +x /opt/homebrew/bin/oc-compliance
 
-Alternatively, build the plugin from source using Go.
+```
 
 
 Subcommands

--- a/README.md
+++ b/README.md
@@ -6,6 +6,46 @@ This is an `oc` plugin that is meant to be used with the
 
 It's a set of utilities that make it easier to use the operator.
 
+## Installation
+
+`oc-compliance` is an `oc` plugin. To be discovered by `oc`, the binary must:
+
+- Be named `oc-compliance`
+- Be executable
+- Be located in a directory present in `$PATH`
+
+A prebuilt binary can be extracted from the container image:
+
+```bash
+mkdir -p ~/bin
+
+podman run --rm \
+  -v ~/bin:/mnt/out:Z \
+  registry.redhat.io/compliance/oc-compliance-rhel8:stable \
+  /bin/cp /usr/bin/oc-compliance /mnt/out/
+
+chmod +x ~/bin/oc-compliance
+```
+
+Ensure `~/bin` is on your `$PATH`, then verify:
+
+```bash
+oc plugin list
+oc compliance -h
+```
+
+### macOS / Apple Silicon
+
+The container image is currently published for `linux/amd64` only.  
+On Apple Silicon, build it :
+
+```bash
+make build
+```
+
+Alternatively, build the plugin from source using Go.
+
+
 Subcommands
 -----------
 


### PR DESCRIPTION
This adds a short Installation section to the README explaining how to install oc-compliance as an oc plugin, including a brief note for macOS / Apple Silicon users.